### PR TITLE
Fix #25

### DIFF
--- a/demoSrc/demo.js
+++ b/demoSrc/demo.js
@@ -31,7 +31,7 @@ export class Demo {
     const sleepWatcher = new SleepWatcher(dragWatcher, { timeOut_ms: 1000 });
 
     const rotor = new AutoSphericalRotor(sleepWatcher, control);
-    rotor.start({
+    rotor.watch({
       minTheta: -Math.PI / 4,
       maxTheta: Math.PI / 4,
       minPhi: 0,
@@ -48,5 +48,5 @@ export class Demo {
 }
 
 window.onload = () => {
-  const demo = new Demo();
+  new Demo();
 };

--- a/demoSrc/demoHorizontalRotation.js
+++ b/demoSrc/demoHorizontalRotation.js
@@ -31,7 +31,7 @@ export class Demo {
     const sleepWatcher = new SleepWatcher(dragWatcher, { timeOut_ms: 1000 });
 
     const rotor = new AutoSphericalRotor(sleepWatcher, control);
-    rotor.start({
+    rotor.watch({
       speed: 0.005,
       minPhi: 0,
       maxPhi: Math.PI / 2,
@@ -47,5 +47,5 @@ export class Demo {
 }
 
 window.onload = () => {
-  const demo = new Demo();
+  new Demo();
 };

--- a/src/SphericalRotor.ts
+++ b/src/SphericalRotor.ts
@@ -29,8 +29,8 @@ export class SphericalRotor {
     this._config = parameters;
   }
 
-  public startRotation = () => {
-    this.stopRotation();
+  public rotate(): void {
+    this.stop();
 
     if (this.isRotation) return;
 
@@ -76,6 +76,13 @@ export class SphericalRotor {
     }
 
     this.isRotation = true;
+  }
+
+  /**
+   * @deprecated use rotate();
+   */
+  public startRotation = () => {
+    this.rotate();
   };
 
   /**
@@ -94,6 +101,7 @@ export class SphericalRotor {
 
   /**
    * カメラの自動回転を停止する
+   * @deprecated use stop()
    */
   public stopRotation = () => {
     this.stop();
@@ -171,14 +179,8 @@ export class AutoSphericalRotor extends SphericalRotor {
   }
 
   private stopWatcher(): void {
-    this.sleepWatcher.removeEventListener(
-      SleepEventType.SLEEP,
-      this.startRotation
-    );
-    this.sleepWatcher.removeEventListener(
-      SleepEventType.WAKEUP,
-      this.stopRotation
-    );
+    this.sleepWatcher.removeEventListener(SleepEventType.SLEEP, this.onSleep);
+    this.sleepWatcher.removeEventListener(SleepEventType.WAKEUP, this.onWakeup);
     this.sleepWatcher.stop();
   }
 
@@ -195,23 +197,35 @@ export class AutoSphericalRotor extends SphericalRotor {
 
   /**
    * マウスの監視を開始する。
+   * @param parameters
+   * @deprecated use watch();
    */
   public start(parameters?: SphericalRotorConfig): void {
+    this.watch(parameters);
+  }
+
+  /**
+   * マウスの監視を開始する。
+   * @param parameters
+   */
+  public watch(parameters?: SphericalRotorConfig): void {
     this.config = parameters;
     this.isStart = true;
     this.startWatcher();
   }
 
+  public onSleep = () => {
+    this.rotate();
+  };
+
+  public onWakeup = () => {
+    this.stop();
+  };
+
   private startWatcher(): void {
     this.stopWatcher();
-    this.sleepWatcher.addEventListener(
-      SleepEventType.SLEEP,
-      this.startRotation
-    );
-    this.sleepWatcher.addEventListener(
-      SleepEventType.WAKEUP,
-      this.stopRotation
-    );
+    this.sleepWatcher.addEventListener(SleepEventType.SLEEP, this.onSleep);
+    this.sleepWatcher.addEventListener(SleepEventType.WAKEUP, this.onWakeup);
     this.sleepWatcher.start();
   }
 }


### PR DESCRIPTION
startRotation stopRotation関数はsleep, wakeupのイベントリスナーとしてのみ必要なのでAutoSphericalRotor

1. onSleep
2. onWakeup

として移動。

startというは名前はSphericalRotorの場合は回転開始
AutoSphericalRotorの場合はマウス監視開始の意味で重複するため、

1. SphericalRotor.rotate()
2. AutoSphericalRotor.watch()

に改名。
