### PR TITLE
bump : threejs-spherical-controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@masatomakino/threejs-drag-watcher": "^0.8.1",
-        "@masatomakino/threejs-spherical-controls": "^0.5.2"
+        "@masatomakino/threejs-spherical-controls": "^0.5.3"
       },
       "devDependencies": {
         "@masatomakino/gulptask-demo-page": "^0.7.0",
-        "@tweenjs/tween.js": "^20.0.3",
         "@types/jest": "^29.5.2",
         "@types/three": "^0.154.0",
         "browser-sync": "^2.29.3",
@@ -30,7 +29,7 @@
         "typescript": "^5.1.3"
       },
       "peerDependencies": {
-        "@tweenjs/tween.js": ">=18.6.4 <21.0.0",
+        "@tweenjs/tween.js": "^21.0.0",
         "three": ">=0.126.0 <1.0.0"
       }
     },
@@ -2684,9 +2683,9 @@
       }
     },
     "node_modules/@masatomakino/raf-ticker": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@masatomakino/raf-ticker/-/raf-ticker-0.5.1.tgz",
-      "integrity": "sha512-XxSMz2V7WU2JTvAviNCMIiPq38VT18p68iN4Cd5dALMyd0FTMtLyWt7tZ9CfXfrwkEwKOvibHJUu4uRneT0ChQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@masatomakino/raf-ticker/-/raf-ticker-0.5.2.tgz",
+      "integrity": "sha512-5lE8Y2WCDFfdawY+dyAynU9GE5MfFthMKgIQW/LfjPXiwixRGg7QLZ8ApSYx1qz45yT/UiIC8Uo1tQOphV8v2w==",
       "dependencies": {
         "eventemitter3": "^5.0.1"
       }
@@ -2708,26 +2707,24 @@
       }
     },
     "node_modules/@masatomakino/threejs-spherical-controls": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@masatomakino/threejs-spherical-controls/-/threejs-spherical-controls-0.5.2.tgz",
-      "integrity": "sha512-dy8MwwR/hYl5uA4faz23xJNXQ406Hh63WWjGKEYrY2rB1gEFZM9c3Fp7rrRUWZh+tAIMOdSD3HbyeQG/QBpwwg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@masatomakino/threejs-spherical-controls/-/threejs-spherical-controls-0.5.3.tgz",
+      "integrity": "sha512-OApigMAV74UsDy/kMCRxPOE/MiUIjVMR1Hdzz2K3yT0kdbvyMBXypDDmoDFq7o3hb3CQoU9jETjoLF5SvPClvg==",
       "dependencies": {
-        "@masatomakino/tween.js-ticker": "^0.3.1"
+        "@masatomakino/tween.js-ticker": "^0.4.0",
+        "@tweenjs/tween.js": "^21.0.0"
       },
       "peerDependencies": {
-        "@tweenjs/tween.js": ">=18.6.4 <21.0.0",
         "three": ">=0.126.0 <1.0.0"
       }
     },
     "node_modules/@masatomakino/tween.js-ticker": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@masatomakino/tween.js-ticker/-/tween.js-ticker-0.3.1.tgz",
-      "integrity": "sha512-TLNzvsL81/MrFkvaLGwTxHgnIEcrpkUUDEW9sovsZBrPSDB1j2CDmByIT8gqgpey9MPd0k+MF2LEuo6edXzGhA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@masatomakino/tween.js-ticker/-/tween.js-ticker-0.4.0.tgz",
+      "integrity": "sha512-XOFQzrZ8Qj5tHuDpVEqd5eIIRhGykV3zVOYvUlQ9bL4mI/LwRyq6DUwZc2UpKKuo3Mr5oYmVmlYGIZ9gPl6Mzw==",
       "dependencies": {
-        "@masatomakino/raf-ticker": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@tweenjs/tween.js": "^20.0.3"
+        "@masatomakino/raf-ticker": "^0.5.2",
+        "@tweenjs/tween.js": "^21.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2804,9 +2801,9 @@
       "dev": true
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-20.0.3.tgz",
-      "integrity": "sha512-SYUe1UgY5HM05EB4+0B4arq2IPjvyzKXoklXKxSYrc2IFxGm1cBrqg5XbiB5uwbs0xY5j+rj986NAJMM0KZaUw=="
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-21.0.0.tgz",
+      "integrity": "sha512-qVfOiFh0U8ZSkLgA6tf7kj2MciqRbSCWaJZRwftVO7UbtVDNsZAXpWXqvCDtIefvjC83UJB+vHTDOGm5ibXjEA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,10 @@
   "license": "MIT",
   "dependencies": {
     "@masatomakino/threejs-drag-watcher": "^0.8.1",
-    "@masatomakino/threejs-spherical-controls": "^0.5.2"
+    "@masatomakino/threejs-spherical-controls": "^0.5.3"
   },
   "devDependencies": {
     "@masatomakino/gulptask-demo-page": "^0.7.0",
-    "@tweenjs/tween.js": "^20.0.3",
     "@types/jest": "^29.5.2",
     "@types/three": "^0.154.0",
     "browser-sync": "^2.29.3",
@@ -37,7 +36,6 @@
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "@tweenjs/tween.js": ">=18.6.4 <21.0.0",
     "three": ">=0.126.0 <1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
依存元がtween.jsをpeerDependenciesからdependenciesに変更したため、バージョンの食い違いが発生した。このpackage.jsonでは依存を削除。