### PR TITLE
migrate : tween.js v25

### DIFF
--- a/__test__/AutoSphericalRotor.spec.ts
+++ b/__test__/AutoSphericalRotor.spec.ts
@@ -1,7 +1,7 @@
 import { RAFTicker } from "@masatomakino/raf-ticker";
 import { DragWatcher, SleepWatcher } from "@masatomakino/threejs-drag-watcher";
 import { SphericalController } from "@masatomakino/threejs-spherical-controls";
-import TWEEN, { Easing } from "@tweenjs/tween.js";
+import { Easing } from "@tweenjs/tween.js";
 import { Mesh, PerspectiveCamera } from "three";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { AutoSphericalRotor } from "../src/index.js";
@@ -10,7 +10,6 @@ describe("AutoSphericalRotor", () => {
   let time: number = 0;
   beforeEach(() => {
     time = 0;
-    TWEEN.removeAll();
     RAFTicker.stop();
     RAFTicker.emitTickEvent(0);
     vi.useFakeTimers();

--- a/__test__/SphericalRotor.spec.ts
+++ b/__test__/SphericalRotor.spec.ts
@@ -3,14 +3,13 @@ import {
   SphericalController,
   SphericalParamType,
 } from "@masatomakino/threejs-spherical-controls";
-import TWEEN, { Easing } from "@tweenjs/tween.js";
+import { Easing } from "@tweenjs/tween.js";
 import { Mesh, PerspectiveCamera } from "three";
 import { beforeEach, describe, expect, test } from "vitest";
 import { SphericalRotor } from "../src/index.js";
 
 describe("SphericalRotor", () => {
   beforeEach(() => {
-    TWEEN.removeAll();
     RAFTicker.stop();
     RAFTicker.emitTickEvent(0);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "peerDependencies": {
         "@masatomakino/threejs-drag-watcher": "0.10.1 - 0.12.x",
-        "@masatomakino/threejs-spherical-controls": "^0.9.0",
+        "@masatomakino/threejs-spherical-controls": "^0.10.0",
         "three": ">=0.126.0 <1.0.0"
       }
     },
@@ -2213,26 +2213,15 @@
       }
     },
     "node_modules/@masatomakino/threejs-spherical-controls": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@masatomakino/threejs-spherical-controls/-/threejs-spherical-controls-0.9.3.tgz",
-      "integrity": "sha512-jO3mwJuVhxgctgyVJIxAr2t7z/8lrY0xhij4Y4XeyhAiFVYqQ4iJpHk8P/k85Syp2X++iTTFefD+E1SR+5DPvw==",
-      "peer": true,
-      "dependencies": {
-        "eventemitter3": "^5.0.1"
-      },
-      "peerDependencies": {
-        "@masatomakino/tween.js-ticker": "0.6.0 - 0.7.x",
-        "three": ">=0.126.0 <1.0.0"
-      }
-    },
-    "node_modules/@masatomakino/tween.js-ticker": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@masatomakino/tween.js-ticker/-/tween.js-ticker-0.7.0.tgz",
-      "integrity": "sha512-lySHKQUqmBeMw2hUmowdVozP4H5L/PaLrf9u4ZEeXU0Yi5vJAVIXRN1AQ3lBaw8SQLY1LNm6f78RBtHnrjAPQg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@masatomakino/threejs-spherical-controls/-/threejs-spherical-controls-0.10.0.tgz",
+      "integrity": "sha512-cMWF5py4+pdWHoDD28rIkeGfz0jY78l2sZ4SeKEvcbNlWwtazxyyemVUCNnb2sKOBziWIY2URozIVLOB+xb5Mw==",
       "peer": true,
       "peerDependencies": {
         "@masatomakino/raf-ticker": "0.5.3 - 0.6.x",
-        "@tweenjs/tween.js": "^18.6.4 || ^19.0.0 || ^20.0.3 || ^21.0.0"
+        "@tweenjs/tween.js": "^25.0.0",
+        "eventemitter3": "^5.0.1",
+        "three": ">=0.126.0 <1.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2482,9 +2471,9 @@
       "dev": true
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-21.0.0.tgz",
-      "integrity": "sha512-qVfOiFh0U8ZSkLgA6tf7kj2MciqRbSCWaJZRwftVO7UbtVDNsZAXpWXqvCDtIefvjC83UJB+vHTDOGm5ibXjEA==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "peer": true
     },
     "node_modules/@types/cookie": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@masatomakino/threejs-drag-watcher": "0.10.1 - 0.12.x",
-    "@masatomakino/threejs-spherical-controls": "^0.9.0",
+    "@masatomakino/threejs-spherical-controls": "^0.10.0",
     "three": ">=0.126.0 <1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
tween.jsに依存するthreejs-spherical-controlsを更新