### PR TITLE
fix: restore SphericalRotorConfigUtil namespace export for backward compatibility

### DIFF
--- a/src/SphericalRotorConfig.ts
+++ b/src/SphericalRotorConfig.ts
@@ -1,9 +1,3 @@
-import type { SphericalParamType } from "@masatomakino/threejs-spherical-controls";
-import {
-  DEFAULT_LOOP_LAT_DURATION,
-  DEFAULT_LOOP_R_DURATION,
-} from "./AutoSphericalRotorConstants.js";
-
 /**
  * 回転の動作を指定する。
  */
@@ -41,54 +35,4 @@ export interface LoopParameter {
   max?: number; // 単位ラジアン or R
   min?: number;
   duration?: number; //単位ms
-}
-
-/**
- * Initialize a SphericalRotorConfig with default values
- */
-export function initConfig(
-  config?: SphericalRotorConfig,
-): SphericalRotorConfig {
-  const result = config ? { ...config } : {};
-  result.loopPhi ??= {};
-  result.loopPhi.duration ??= DEFAULT_LOOP_LAT_DURATION;
-  result.loopTheta ??= {};
-  result.loopTheta.duration ??= DEFAULT_LOOP_LAT_DURATION;
-  result.loopR ??= {};
-  result.loopR.duration ??= DEFAULT_LOOP_R_DURATION;
-  return result;
-}
-
-/**
- * ループアニメーションに必要な情報を、configオブジェクトから取り出す。
- * @param config
- * @param type
- */
-export function extractSphericalParam(
-  config: SphericalRotorConfig | undefined,
-  type: SphericalParamType,
-): Required<LoopParameter> | undefined {
-  const getLoopParameter = (
-    config: SphericalRotorConfig | undefined,
-    type: SphericalParamType,
-  ): LoopParameter | undefined => {
-    switch (type) {
-      case "phi":
-        return config?.loopPhi;
-      case "theta":
-        return config?.loopTheta;
-      case "radius":
-        return config?.loopR;
-    }
-  };
-
-  const param = getLoopParameter(config, type);
-  if (
-    param == null ||
-    param.max == null ||
-    param.min == null ||
-    param.duration == null
-  )
-    return undefined;
-  return param as Required<LoopParameter>;
 }

--- a/src/SphericalRotorConfigUtil.ts
+++ b/src/SphericalRotorConfigUtil.ts
@@ -1,0 +1,59 @@
+import {
+  DEFAULT_LOOP_LAT_DURATION,
+  DEFAULT_LOOP_R_DURATION,
+} from "./AutoSphericalRotorConstants.js";
+import type {
+  LoopParameter,
+  SphericalRotorConfig,
+} from "./SphericalRotorConfig.js";
+import type { SphericalParamType } from "@masatomakino/threejs-spherical-controls";
+
+/**
+ * Initialize a SphericalRotorConfig with default values
+ */
+export function initConfig(
+  config?: SphericalRotorConfig,
+): SphericalRotorConfig {
+  const result = config ? { ...config } : {};
+  result.loopPhi ??= {};
+  result.loopPhi.duration ??= DEFAULT_LOOP_LAT_DURATION;
+  result.loopTheta ??= {};
+  result.loopTheta.duration ??= DEFAULT_LOOP_LAT_DURATION;
+  result.loopR ??= {};
+  result.loopR.duration ??= DEFAULT_LOOP_R_DURATION;
+  return result;
+}
+
+/**
+ * ループアニメーションに必要な情報を、configオブジェクトから取り出す。
+ * @param config
+ * @param type
+ */
+export function extractSphericalParam(
+  config: SphericalRotorConfig | undefined,
+  type: SphericalParamType,
+): Required<LoopParameter> | undefined {
+  const getLoopParameter = (
+    config: SphericalRotorConfig | undefined,
+    type: SphericalParamType,
+  ): LoopParameter | undefined => {
+    switch (type) {
+      case "phi":
+        return config?.loopPhi;
+      case "theta":
+        return config?.loopTheta;
+      case "radius":
+        return config?.loopR;
+    }
+  };
+
+  const param = getLoopParameter(config, type);
+  if (
+    param == null ||
+    param.max == null ||
+    param.min == null ||
+    param.duration == null
+  )
+    return undefined;
+  return param as Required<LoopParameter>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,10 @@ export * from "./SphericalRotor.js";
 export * from "./AutoSphericalRotor.js";
 export * from "./RotorStopConfig.js";
 export * from "./SphericalRotorConfig.js";
+export * from "./SphericalRotorConfigUtil.js";
+
+import * as SphericalRotorConfigUtil from "./SphericalRotorConfigUtil.js";
+/**
+ * @deprecated Use named exports directly from "@masatomakino/threejs-spherical-rotor" instead.
+ */
+export { SphericalRotorConfigUtil };


### PR DESCRIPTION
## Changes

This PR restores the SphericalRotorConfigUtil namespace export to maintain backward compatibility with existing code that may be using it, while still encouraging the use of named exports.

### Implementation Details

- Moved utility functions (`initConfig` and `extractSphericalParam`) from SphericalRotorConfig.ts to a dedicated SphericalRotorConfigUtil.ts file
- Exported individual functions using named exports
- Added a namespace export with a deprecation notice to guide users toward the preferred named export pattern


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced utility functions for initializing and extracting spherical rotor configuration parameters.
- **Refactor**
  - Moved configuration logic to a new utility module for improved modularity.
- **Documentation**
  - Added a deprecation notice for the namespace export, recommending direct named imports instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->