### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,10 +1,13 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to v11.6.0
+        run: npm install -g npm@11.6.0
       - run: npm ci
       - name: build binary
         run: npm run buildTS
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication.

## Changes

- ✅ NPM Trusted Publisher configured on npmjs.com
- ✅ Publishing access set to "Require two-factor authentication and disallow tokens"
- ✅ Added OIDC permissions to GitHub Actions workflow
- ✅ Added npm upgrade step for latest OIDC support
- ✅ Removed NPM token authentication from workflow
- ✅ Changed release trigger to `published` only (was `created`)

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

The migration can be tested by creating a release after this PR is merged. The workflow should successfully publish to NPM using Trusted Publisher authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger on “published” releases.
  * Added job-level permissions to support repository access and OIDC authentication.
  * Introduced an upfront upgrade to npm v11.6.0 before dependency installation.
  * Switched authentication to OIDC, removing the explicit NODE_AUTH_TOKEN variable.
  * Maintained existing build and publish steps while refining the workflow sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->